### PR TITLE
add config option for gpt model

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -7,8 +7,8 @@ class Config:
     _config.read("config.ini")
 
     @classmethod
-    def get(cls, section, option):
-        return cls._config.get(section, option, fallback=None)
+    def get(cls, section, option, fallback=None):
+        return cls._config.get(section, option, fallback=fallback)
 
     @classmethod
     def set(cls, section, option, value):

--- a/OpenAI.py
+++ b/OpenAI.py
@@ -15,6 +15,7 @@ class OpenAI:
         error_message,
         memory_size=10,
         chat_wide_conversation=False,
+        gpt_model="gpt-3.5-turbo",
     ) -> None:
         openai.organization = org
         openai.api_key = key
@@ -26,6 +27,7 @@ class OpenAI:
         self.conversations_status = {}
         self.memory_size = int(memory_size)
         self.chat_wide_conversation = chat_wide_conversation
+        self.gpt_model = gpt_model
 
     def start_conversation(self, conversation_id, author):
         self.conversations[conversation_id] = [
@@ -88,7 +90,7 @@ class OpenAI:
             if assistant_message:
                 json_messages.append(assistant_message.__dict__)
             response = await openai.ChatCompletion.acreate(
-                model="gpt-3.5-turbo-0613",
+                model=self.gpt_model,
                 messages=json_messages,
             )
             logging.info(response)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ chat_level = VIEWER
 shoutouts = yes [leave blank or delete row to disable]
 shoutout_level = VIP
 all_mentions = yes [leave blank or delete row to disable]
+gpt_model = gpt-3.5-turbo [defaults to gpt-3.5-turbo if not set]
 ```
 7. Run the bot
 ```
@@ -81,9 +82,12 @@ python main.py
 - Thinking message: The message the bot will send while it is thinking
 - Error message: The message the bot will send if it encounters an error
 - Memory: The number of messages the bot will remember
+- Chat Wide Conversation: If active, the bot will treat the whole channel as a single conversation, instead of individual users
 - Chat level: The level required to chat with the bot. Viewer, VIP, Subscriber, Moderator, Broadcaster
 - Shoutouts: If the bot should respond to !so commands
 - Shoutout level: The level required to trigger shoutouts.  Viewer, VIP, Subscriber, Moderator, Broadcaster
+- All mentions = If the bot should respond to all mentions of its name, or only when directly addressed
+- GPT Model = The OpenAI model used for generating responses. Defaults to gpt-3.5-turbo if not set
 
 # System operations
 After creating a config.ini file, according to the config.ini-example, you can start the bot by running the main.py script.

--- a/TwitchBot.py
+++ b/TwitchBot.py
@@ -51,6 +51,7 @@ class TwitchBot(commands.Bot):
             Config.get(channel.name, "error_message"),
             Config.get(channel.name, "memory_size"),
             Config.get(channel.name, "chat_wide_conversation"),
+            Config.get(channel.name, "gpt_model", fallback="gpt-3.5-turbo"),
         )
 
     async def event_message(self, message):

--- a/config.ini-example
+++ b/config.ini-example
@@ -17,3 +17,4 @@ chat_level = VIEWER
 shoutouts = yes [leave blank or delete row to disable]
 shoutout_level = VIP
 all_mentions = yes [leave blank or delete row to disable]
+gpt_model = gpt-3.5-turbo [defaults to gpt-3.5-turbo]


### PR DESCRIPTION
### Add option for OpenAI model version.
This will default to **gpt-3.5-turbo** unless otherwise specified.
This option will be set on a per-channel level